### PR TITLE
fixes tinymce/iframe editors not detected

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -9,7 +9,6 @@
 	<link href="../css/editor.min.css" rel="stylesheet">
 
 	<script src="../js/editor.min.js"></script>
-	<script src="../js/primitiveExtend.js"></script>
 	<script src="../js/options.js"></script>
 	<script src="../js/detector.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/js/background.js
+++ b/js/background.js
@@ -6,7 +6,11 @@
 
 import { q, isTabSafe, checkRuntimeError } from "./pre";
 import { Folder, Generic } from "./snippet_classes";
+import { primitiveExtender } from "./primitiveExtend";
+import { updateAllValuesPerWin } from "./protoExtend";
 
+primitiveExtender();
+updateAllValuesPerWin(window);
 console.log(`Loaded once ${new Date()}`);
 const BLOCK_SITE_ID = "blockSite",
     // for gettting the blocked site status in case of unfinished loading of cs.js

--- a/js/detector.js
+++ b/js/detector.js
@@ -8,13 +8,16 @@ import {
     isTextNode,
     isBlockedSite,
     escapeRegExp,
+    PRIMITIVES_EXT_KEY,
 } from "./pre";
 import { Folder, Snip } from "./snippet_classes";
 import { changeStorageType, DBLoad } from "./common_data_handlers";
+import { primitiveExtender } from "./primitiveExtend";
 import { updateAllValuesPerWin } from "./protoExtend";
 import { getHTML } from "./textmethods";
 import { showBlockSiteModal } from "./modalHandlers";
 
+primitiveExtender();
 (function () {
     let windowLoadChecker = setInterval(() => {
             if (window.document.readyState === "complete") {
@@ -84,7 +87,7 @@ import { showBlockSiteModal } from "./modalHandlers";
                 setInterval(initiateIframeCheck, IFRAME_CHECK_TIMER, doc);
             }
         } catch (e) {
-            debugLog(e, iframe);
+            debugLog(e, iframe, doc, win);
         }
     }
 
@@ -1096,7 +1099,11 @@ import { showBlockSiteModal } from "./modalHandlers";
             setTimeout(init, 1000);
             return;
         }
-        debugLog("init", document);
+        if (!window[PRIMITIVES_EXT_KEY]) {
+            updateAllValuesPerWin(window);
+        }
+
+        debugLog("---\ninit", document);
 
         // another instance is already running, time to escape
         if (document[UNIQ_CS_KEY] === true) {

--- a/js/options.js
+++ b/js/options.js
@@ -25,13 +25,17 @@ import {
     escapeRegExp,
     protoWWWReplaceRegex,
     debounce,
+    PRIMITIVES_EXT_KEY,
 } from "./pre";
 import { DualTextbox, Folder } from "./snippet_classes";
 import { ensureRobustCompat } from "./restoreFns";
 import { initBackup } from "./backupWork";
 import { initSnippetWork } from "./snippetWork";
 import { getHTML } from "./textmethods";
+import { updateAllValuesPerWin } from "./protoExtend";
+import { primitiveExtender } from "./primitiveExtend";
 
+primitiveExtender();
 (function () {
     let $autoInsertTable,
         $tabKeyInput,
@@ -316,9 +320,8 @@ import { getHTML } from "./textmethods";
     }
 
     function init() {
-        if (!window.primitivesExtended) {
-            setTimeout(init, 100);
-            return;
+        if (!window[PRIMITIVES_EXT_KEY]) {
+            updateAllValuesPerWin(window);
         }
         // needs to be set before database actions
         $panelSnippets = qClsSingle("panel_snippets");

--- a/js/pre.js
+++ b/js/pre.js
@@ -111,6 +111,7 @@ if (DEBUGGING) {
 const debugLog = debugLogTemp,
     debugDir = debugDirTemp,
     SHOW_CLASS = "show",
+    PRIMITIVES_EXT_KEY = "primitivesExtended",
     protoWWWReplaceRegex = /^(ht|f)tps?:\/\/(www\.)?/,
     OBJECT_NAME_LIMIT = 60;
 
@@ -299,4 +300,5 @@ export {
     protoWWWReplaceRegex,
     debounce,
     OBJECT_NAME_LIMIT,
+    PRIMITIVES_EXT_KEY,
 };

--- a/js/primitiveExtend.js
+++ b/js/primitiveExtend.js
@@ -2,10 +2,15 @@
 // it is indcluded with the other files
 
 import { DOM_HELPERS } from "./pre";
-import { extendNodePrototype, updateAllValuesPerWin } from "./protoExtend";
+import { extendNodePrototype } from "./protoExtend";
 import { getHTML, setHTML } from "./textmethods";
 
-(function () {
+/**
+ * There are three frames in which this needs to be executed
+ * options page, background page, and all frames of a webpage.
+ * This does not need to wait for page load.
+ */
+export function primitiveExtender() {
     Date.MONTHS = [
         "January",
         "February",
@@ -324,14 +329,4 @@ import { getHTML, setHTML } from "./textmethods";
     for (const [funcName, func] of Object.entries(DOM_HELPERS)) {
         extendNodePrototype(funcName, func);
     }
-}());
-
-function onPageLoad() {
-    if (document.readyState !== "complete") {
-        setTimeout(onPageLoad, 10);
-    } else {
-        updateAllValuesPerWin(window);
-        window.primitivesExtended = true;
-    }
 }
-onPageLoad();

--- a/js/protoExtend.js
+++ b/js/protoExtend.js
@@ -1,3 +1,5 @@
+import { PRIMITIVES_EXT_KEY } from "./pre";
+
 const protoExtensions = {};
 
 function setNodeListPropPerWindow(prop, func, win) {
@@ -24,6 +26,7 @@ function updateAllValuesPerWin(win) {
     for (const [name, func] of Object.entries(protoExtensions)) {
         setNodeListPropPerWindow(name, func, win);
     }
+    win[PRIMITIVES_EXT_KEY] = true;
 }
 
 /**

--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
         "default_icon": "imgs/r16.png"
     },
     "background": {
-        "scripts": ["js/primitiveExtend.js", "js/background.js"],
+        "scripts": ["js/background.js"],
         "persistent": false
     },
     "content_scripts": [
         {
-            "js": ["js/primitiveExtend.js", "js/detector.js"],
+            "js": ["js/detector.js"],
             "css": ["css/blockSiteModal.css"],
             "matches": ["<all_urls>"],
             "run_at": "document_start",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,6 @@ module.exports = {
         background: `${__dirname}/js/background.js`,
         detector: `${__dirname}/js/detector.js`,
         options: `${__dirname}/js/options.js`,
-        primitiveExtend: `${__dirname}/js/primitiveExtend.js`,
     },
     output: {
         filename: "[name].js",


### PR DESCRIPTION
method: corrected proto extensions logic
now each of the three main files must call primitiveExtenders...
to extend the prototype. and then we would call updateAllValues for...
each of their windows on load