### PR TITLE
Prevent parse error when revisions are missing

### DIFF
--- a/js/commonDataHandlers.js
+++ b/js/commonDataHandlers.js
@@ -45,7 +45,7 @@ function notifySnippetDataChanges(snippetList) {
  */
 function saveRevision(dataString) {
     const MAX_REVISIONS_STORED = 20;
-    let parsed = JSON.parse(localStorage[LS_REVISIONS_PROP]);
+    let parsed = JSON.parse(localStorage[LS_REVISIONS_PROP] || "[]");
     const latestRevision = {
         label: `${getFormattedDate()} - ${window.latestRevisionLabel}`,
         data: dataString || Data.snippets,


### PR DESCRIPTION
When prokeys_revisions is missing or renamed, a parse error occurs and the extension becomes unusable
I modified only one occurence but there are more
I suggest creating a wrapper function around JSON.parse and mapping each key to a default value then if a parse exception occurs, the wrapper function would return the fallback default value i.e "{}" or "[]" etc

Or it could make data checks at first and fill default data if none found or if data is invalid